### PR TITLE
ci: initial CI and deploy workflows

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -1,0 +1,16 @@
+name: Set up deps
+description: Loads NPM dependencies for a CI job, installing them if not cached
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/tools
+
+    - uses: actions/cache@v2
+      id: deps-cache
+      with:
+        path: node_modules
+        key: ${{ env.CACHE_UUID }}-node-${{ hashFiles('package-lock.json') }}
+
+    - run: npm ci
+      shell: bash
+      if: "!steps.deps-cache.outputs.cache-hit"

--- a/.github/actions/tools/action.yml
+++ b/.github/actions/tools/action.yml
@@ -1,0 +1,15 @@
+name: Set up tools
+description: Loads asdf tools for a CI job, installing them if not cached
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v2
+      id: asdf-cache
+      with:
+        path: ~/.asdf
+        key: ${{ env.CACHE_UUID }}-asdf-${{ hashFiles('.tool-versions') }}
+
+    - uses: asdf-vm/actions/install@v1
+      if: "!steps.asdf-cache.outputs.cache-hit"
+
+    - uses: mbta/actions/reshim-asdf@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - "*.md"
+      - LICENSE
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CACHE_UUID: ${{ secrets.CACHE_UUID }}
+
+jobs:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/deps
+      - run: node_modules/.bin/prettier --check .
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/deps
+      - run: npm run lint
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/tools
+      - run: shellcheck *.sh
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/deps
+      - run: npm test
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/deps
+      - run: npm run check

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,24 @@
+name: Deploy to Dev
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success'
+      }}
+    environment: dev
+    concurrency: deploy-dev
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "Not implemented"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,15 @@
+name: Deploy to Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: prod
+    concurrency: deploy-prod
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "Not implemented"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 14.19.0
+shellcheck 0.8.0


### PR DESCRIPTION
In the CI workflow, I took advantage of "composite actions" to DRY up some of the caching logic that in other repos we've duplicated in each job definition. Initially I gave the composite actions an `install` option that controlled whether tools/deps would be installed on a cache miss, allowing for the separate "setup" job we commonly have. But, while this did create some [neat flowcharts](https://user-images.githubusercontent.com/394835/155399402-036a3935-f55b-454c-8c6b-ff4bf5c75651.png), I realized we didn't really need it — all it does is prevent a bit of extra CI time (but not real time) from being wasted in the uncommon case when the tools or deps are modified.

The deploy workflows are just stubs to enable the manual "dispatch" UI in the repo, allowing them to be further developed on a branch without merging things to main. I thought about modeling this on `alerts_concierge` where all environments are handled by a single workflow with an input to specify the environment, but IIRC the team was "meh" on that approach, so it's separate. With composite actions we should be able to keep it DRY anyway.