### PR TITLE
dev: add Sentry integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2224,6 +2224,94 @@
         "fastq": "^1.6.0"
       }
     },
+    "@sentry/core": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.1.tgz",
+      "integrity": "sha512-ZSIFnwYCzABK1jX1iMwUbaAoWbbJear0wM+gSZvJpSUJ1dAXV1OZyL7kXtEJRtATahIlcrMou5ewIoeJizeWAw==",
+      "requires": {
+        "@sentry/hub": "6.19.1",
+        "@sentry/minimal": "6.19.1",
+        "@sentry/types": "6.19.1",
+        "@sentry/utils": "6.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.1.tgz",
+      "integrity": "sha512-BgUwdxxXntGohAYrXtYrYBA6QzOeRz3NINuS838n7SRTkGf9gBJ/Rd3dyOWUrzJciKty7rmvYIwTA0oo91AMkw==",
+      "requires": {
+        "@sentry/types": "6.19.1",
+        "@sentry/utils": "6.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.1.tgz",
+      "integrity": "sha512-Xre3J6mjWEcQhDmQ3j4g71J8f0nDgg2p7K41SngibfZVYSOe8jAowxSI9JuWD7juuwT5GVRVCqLs+Y6mWDBaoQ==",
+      "requires": {
+        "@sentry/hub": "6.19.1",
+        "@sentry/types": "6.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.1.tgz",
+      "integrity": "sha512-ipPWFY+1gNZlt99QHInP+Z70W7nYeBEEiVDtpxSMid5zFzPJ/k9QOZtUzyelyiSCBvIIeTzVX9Fyri17fay1Pw==",
+      "requires": {
+        "@sentry/core": "6.19.1",
+        "@sentry/hub": "6.19.1",
+        "@sentry/types": "6.19.1",
+        "@sentry/utils": "6.19.1",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/serverless": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.19.1.tgz",
+      "integrity": "sha512-GGbiMFIHLjjIj0KgU33rKy+ICfaYlJRb00clq+r1CjODjY+iXXJLG0Nmgx4qmmotMkK8xRWDPzhJEGGMJM2TUg==",
+      "requires": {
+        "@sentry/minimal": "6.19.1",
+        "@sentry/node": "6.19.1",
+        "@sentry/tracing": "6.19.1",
+        "@sentry/types": "6.19.1",
+        "@sentry/utils": "6.19.1",
+        "@types/aws-lambda": "^8.10.62",
+        "@types/express": "^4.17.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.19.1.tgz",
+      "integrity": "sha512-o34+h0j70dszcIwpCIbmO4UauPurpqLvcPO3JsFhRdxQhwQaQgMwhFklbAt7al9oEDYkjlS0gzhhlOCz4IS9kA==",
+      "requires": {
+        "@sentry/hub": "6.19.1",
+        "@sentry/minimal": "6.19.1",
+        "@sentry/types": "6.19.1",
+        "@sentry/utils": "6.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.1.tgz",
+      "integrity": "sha512-ovmNYdqD2MKLmru4calxetX1xjJdYim+HEI/GzwvVUYshsaXRq4EiQ17h3DAy90MV7JH279PmMoPGDTOpufq+Q=="
+    },
+    "@sentry/utils": {
+      "version": "6.19.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.1.tgz",
+      "integrity": "sha512-mWcQbQ1yO7PooLpJpQK84+wOfxGeb8iUKRb8inO+2Eg6VksDbXRuJ89Yd4APBTRxBj5Wihy48bPuVfKtovtm8g==",
+      "requires": {
+        "@sentry/types": "6.19.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -2257,8 +2345,7 @@
     "@types/aws-lambda": {
       "version": "8.10.93",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
-      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==",
-      "dev": true
+      "integrity": "sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A=="
     },
     "@types/babel__core": {
       "version": "7.1.18",
@@ -2299,6 +2386,44 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
       }
     },
     "@types/graceful-fs": {
@@ -2356,6 +2481,11 @@
       "integrity": "sha512-mWXdRlg+5dWvxU+uaijB2RY5NrJtMEXR6j+D6W66hPuezSVXrQqQvWa/JNHntgEYgjzeoVRrQVmMWAbKjUJiFQ==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+    },
     "@types/minipass": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.1.2.tgz",
@@ -2368,8 +2498,7 @@
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
-      "dev": true
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "@types/prettier": {
       "version": "2.4.4",
@@ -2377,12 +2506,31 @@
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
     "@types/s3rver": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@types/s3rver/-/s3rver-3.7.0.tgz",
       "integrity": "sha512-EoVqpsY0Bfr98l0SzQWn5ZoyAFVr26V/k7hTePOMrOmcMl96/z5RvhzQgQ/2K+GTGutHFmvMfnnMuDLoPG9BCQ==",
       "dev": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+      "requires": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -2596,7 +2744,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -3046,6 +3193,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
     "cookies": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
@@ -3113,7 +3265,6 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -4100,7 +4251,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -5126,6 +5276,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
     "luxon": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.3.1.tgz",
@@ -5250,8 +5405,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.1",
     "@aws-sdk/lib-storage": "^3.54.1",
+    "@sentry/serverless": "^6.19.1",
     "luxon": "^2.3.1",
     "superstruct": "^0.15.4",
     "tar": "^6.1.11"

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -1,10 +1,10 @@
 import { DateTime } from "luxon";
+import { exception } from "./errors";
 
 const TZ = "America/New_York";
-class InvalidDatetimeError extends Error {}
 
 export const localFromISO = (iso: string) => {
   const datetime = DateTime.fromISO(iso).setZone(TZ);
-  if (!datetime.isValid) throw new InvalidDatetimeError(iso);
+  if (!datetime.isValid) throw exception("InvalidDatetime", iso);
   return datetime;
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Convenience function for constructing errors where the `name` property has a
+ * given value. This enables easier identification and grouping in e.g. Sentry.
+ */
+export const exception = (name: string, message: string) => {
+  const error = new Error(message);
+  error.name = name;
+  // Omit this function from the stack trace
+  Error.captureStackTrace(error, exception);
+  return error;
+};


### PR DESCRIPTION
I tested this in dev by deploying versions of the scripts that intentionally threw errors (the helper for creating "named" errors and the cutoff for processor errors are a result of this). Everything seems to show up correctly now, including stack traces and errors being tagged with the specific Lambda that generated them (packager/processor).

I didn't set up source maps yet, since this has some extra complexity (it requires setting up "releases") and I'm not sure whether it's worth our while. It's straightforward to bundle the scripts locally and get the same combined `.js` file that is shipped to Lambda, and thus appears in Sentry stack traces. The only disadvantage might be that Sentry doesn't know which lines are "our code" and which are libraries, for grouping purposes.