### PR TITLE
ci: fix dry-run deploy failure in dependabot PRs

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -7,13 +7,15 @@ inputs:
   aws-secret-access-key:
     description: AWS secret key
     required: true
+  dry-run:
+    description: >-
+      If truthy, the deploy will be a dry run, or will not be attempted at all
+      if `aws-access-key-id` is blank (instead of erroring)
+    required: false
+    default: ""
   environment:
     description: Name of the environment to deploy to (dev/prod)
     required: true
-  options:
-    description: Extra options to be passed to the `aws` commands
-    required: false
-    default: ""
 runs:
   using: composite
   steps:
@@ -28,8 +30,9 @@ runs:
         aws lambda update-function-code
         --function-name ocs-saver-${{ inputs.environment }}-packager
         --zip-file fileb://dist/packager.zip
-        ${{ inputs.options }}
+        ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
+      if: ${{ !inputs.dry-run || inputs.aws-access-key-id }}
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
@@ -39,8 +42,9 @@ runs:
         aws lambda update-function-code
         --function-name ocs-saver-${{ inputs.environment }}-firehose-processor
         --zip-file fileb://dist/processor.zip
-        ${{ inputs.options }}
+        ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
+      if: ${{ !inputs.dry-run || inputs.aws-access-key-id }}
       env:
         AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          dry-run: "true"
           environment: dev
-          options: --dry-run
 
   format:
     name: Format


### PR DESCRIPTION
Dependabot PRs are treated as "fork PRs" for security reasons, meaning they don't have access to the repo secrets. This caused all Dependabot PRs to fail CI because AWS keys were blank for the dry-run deploy.

We can fix this by effectively making the AWS keys optional when the dry-run option is used, and if they aren't present, not running the `aws` command (but still going through the packaging process, thus doing _as much_ of a dry run as we can).

This is one possible fix; another way would be to skip the dry deploy job entirely if the secrets are not present. I tried to do this, as I thought it would be very simple, but it turned out to be [a huge pain](https://cloudtruth.com/blog/skipping-jobs-in-github-actions-when-secrets-are-unavailable-securely-inject-configuration-secrets-into-github/) because you arbitrarily can't access `secrets` in a job conditional 🙃