### PR TITLE
fix(packager): missing newlines between batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,20 @@ the prod environment packager.
 
 ```
 aws lambda invoke \
+  --invocation-type Event \
   --function-name ocs-saver-dev-packager \
   --payload '{"time": "2022-01-01T12:00:00Z"}' \
-  --cli-binary-format raw-in-base64-out
+  --cli-binary-format raw-in-base64-out \
+  /dev/stdout
 ```
 
-On a failure, the command output will include `"FunctionError": "Unhandled"`,
-otherwise it will not. Note that currently the packager intentionally fails
-when its output file already exists; if you want to regenerate an output file,
-it must first be deleted from S3.
+This example uses async invocation, since a successful run can take longer than
+the CLI's default read timeout. You'll have to use Splunk to monitor the status
+of the run (filter by `source=lambda:ocs-saver-dev-packager-logs`).
+
+Note that currently the packager intentionally fails when its output file
+already exists; if you want to regenerate an output file, it must first be
+deleted from S3.
 
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -61,9 +61,13 @@ This example uses async invocation, since a successful run can take longer than
 the CLI's default read timeout. You'll have to use Splunk to monitor the status
 of the run (filter by `source=lambda:ocs-saver-dev-packager-logs`).
 
-Note that currently the packager intentionally fails when its output file
-already exists; if you want to regenerate an output file, it must first be
-deleted from S3.
+Note by default the packager intentionally fails when its output file already
+exists. If you want to regenerate an output file, add the `overwrite` option to
+the payload:
+
+```
+{"time": "2022-01-01T12:00:00Z", "detail": {"overwrite": true}}
+```
 
 
 ## Architecture

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -72,6 +72,8 @@ export const handler: ScheduledHandler = Sentry.wrapHandler(
  * The filename can contain directories, which are created if they don't exist.
  * If the file already exists, it will be overwritten.
  *
+ * A newline is appended after each object, including the last one.
+ *
  * [1]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html
  */
 const concatAllObjects = async (
@@ -100,6 +102,7 @@ const concatAllObjects = async (
         throw exception("BadS3Response", JSON.stringify(metadata));
 
       await fs.appendFile(outputFile, data);
+      await fs.appendFile(outputFile, "\n");
     }
   }
 

--- a/test/packager.test.ts
+++ b/test/packager.test.ts
@@ -65,11 +65,11 @@ const handle = (event: ScheduledEvent) =>
 
 test("archives all logs for the previous service day", async () => {
   const objects = [
-    ["2021-12-31/ocs", "prev day\n"],
-    ["2022-01-01/ocs1", "one\ntwo\n"],
-    ["2022-01-01/ocs2", "three\nfour\nfive\n"],
-    ["2022-01-01/ocs3", "six\n"],
-    ["2022-01-02/ocs", "next day\n"],
+    ["2021-12-31/ocs", "prev day"],
+    ["2022-01-01/ocs1", "one\ntwo"],
+    ["2022-01-01/ocs2", "three\nfour\nfive"],
+    ["2022-01-01/ocs3", "six"],
+    ["2022-01-02/ocs", "next day"],
   ];
   for (const [key, data] of objects) await putSourceObject(key, data);
 
@@ -82,7 +82,7 @@ test("archives all logs for the previous service day", async () => {
 });
 
 test("doesn't write the output object if it already exists", async () => {
-  const existingOutput = Buffer.from("existing output");
+  const existingOutput = Buffer.from("existing output\n");
   await putSourceObject("2022-01-01/ocs", "new data");
   await putOutputObject("20220101.tar.gz", existingOutput);
 
@@ -95,7 +95,7 @@ test("doesn't write the output object if it already exists", async () => {
 });
 
 test("overwrites the output object if an option is provided", async () => {
-  const existingOutput = Buffer.from("existing output");
+  const existingOutput = Buffer.from("existing output\n");
   await putSourceObject("2022-01-01/ocs", "updated output");
   await putOutputObject("20220101.tar.gz", existingOutput);
 
@@ -108,7 +108,7 @@ test("overwrites the output object if an option is provided", async () => {
 
   const [entry] = await extractOutputObject("20220101.tar.gz");
   const data = (await fs.readFile(entry.fullPath)).toString();
-  expect(data).toEqual("updated output");
+  expect(data).toEqual("updated output\n");
 });
 
 const extractOutputObject = async (key: string) => {


### PR DESCRIPTION
**Asana:** [🍬🐛 OCS Saver linebreak issue](https://app.asana.com/0/584764604969369/1202148457379656)

Includes a small new feature that lets us easily overwrite an output file when invoking the packager manually, since we want to regenerate the files that were affected by this bug.

For a smoke test, I manually deployed this version of the packager to dev and used the `overwrite` option to regenerate `20220330.tar.gz`. Comparing that file between `dev` and `prod`, you can see dev is no longer missing the newlines.