### PR TITLE
chore: make agnostic to new fields coming in from kinesis

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -5,7 +5,7 @@ import {
   FirehoseTransformationResultRecord as ResultRecord,
 } from "aws-lambda";
 import { DateTime } from "luxon";
-import { create as struct } from "superstruct";
+import { mask as struct } from "superstruct";
 import { localFromISO } from "./datetime";
 import { OCSEvent } from "./processor/structs";
 import { wrapList } from "./util";

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ import {
 import { exception } from "./errors";
 import { localFromISO } from "./datetime";
 import { OCSEvent } from "./processor/structs";
-import { create as struct } from "superstruct";
+import { mask as struct } from "superstruct";
 
 export const safeSend = async (
   client: S3Client,

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -19,7 +19,10 @@ const handle = (event: FirehoseTransformationEvent) =>
 const buildFirehoseEvent = (records: FirehoseTransformationEventRecord[]) =>
   firehoseEventFactory.build({ records });
 
-const buildKinesisRecord = (id: string, ocsEventAttrs: any) =>
+const buildKinesisRecord = (
+  id: string,
+  ocsEventAttrs: Record<PropertyKey, string | number | object>
+) =>
   kinesisRecordFactory.build(
     { recordId: id },
     { transient: { encodeEvent: ocsEventFactory.build(ocsEventAttrs) } }
@@ -27,7 +30,7 @@ const buildKinesisRecord = (id: string, ocsEventAttrs: any) =>
 
 const buildKinesisBatchRecord = (
   id: string,
-  ocsEventsAttrs: Array<Partial<OCSEvent>>
+  ocsEventsAttrs: Array<Record<PropertyKey, string | number | object>>
 ) =>
   kinesisRecordFactory.build(
     { recordId: id },

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -77,12 +77,12 @@ test("transforms records to timestamped raw OCS messages - with arbitrary field"
     buildKinesisRecord("rec1", {
       time: "2022-03-01T05:00:02Z",
       data: { raw: "101,DIAG,00:00:01,test1" },
-      sourceip: "127.0.0.1"
+      sourceip: "127.0.0.1",
     }),
     buildKinesisRecord("rec2", {
       time: "2022-03-01T05:00:03Z",
       data: { raw: "102,DIAG,00:00:02,test2" },
-      sourceip: "127.0.0.1"
+      sourceip: "127.0.0.1",
     }),
   ]);
 

--- a/test/processor.test.ts
+++ b/test/processor.test.ts
@@ -19,7 +19,7 @@ const handle = (event: FirehoseTransformationEvent) =>
 const buildFirehoseEvent = (records: FirehoseTransformationEventRecord[]) =>
   firehoseEventFactory.build({ records });
 
-const buildKinesisRecord = (id: string, ocsEventAttrs: Partial<OCSEvent>) =>
+const buildKinesisRecord = (id: string, ocsEventAttrs: any) =>
   kinesisRecordFactory.build(
     { recordId: id },
     { transient: { encodeEvent: ocsEventFactory.build(ocsEventAttrs) } }
@@ -53,6 +53,36 @@ test("transforms records to timestamped raw OCS messages", async () => {
     buildKinesisRecord("rec2", {
       time: "2022-03-01T05:00:03Z",
       data: { raw: "102,DIAG,00:00:02,test2" },
+    }),
+  ]);
+
+  const { records } = (await handle(event)) as FirehoseTransformationResult;
+
+  expect(records.map(decodeRecordData)).toMatchObject([
+    {
+      data: "03/01/22,00:00:02,101,DIAG,00:00:01,test1",
+      recordId: "rec1",
+      result: "Ok",
+    },
+    {
+      data: "03/01/22,00:00:03,102,DIAG,00:00:02,test2",
+      recordId: "rec2",
+      result: "Ok",
+    },
+  ]);
+});
+
+test("transforms records to timestamped raw OCS messages - with arbitrary field", async () => {
+  const event = buildFirehoseEvent([
+    buildKinesisRecord("rec1", {
+      time: "2022-03-01T05:00:02Z",
+      data: { raw: "101,DIAG,00:00:01,test1" },
+      sourceip: "127.0.0.1"
+    }),
+    buildKinesisRecord("rec2", {
+      time: "2022-03-01T05:00:03Z",
+      data: { raw: "102,DIAG,00:00:02,test2" },
+      sourceip: "127.0.0.1"
     }),
   ]);
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🚲 Log Trike sequence breaks](https://app.asana.com/0/584764604969369/1205340304514105/f)

Modifies `ocs_saver` to ignore fields that aren't part of the schema by using `mask` instead of `create` from superstruct (https://github.com/ianstormtaylor/superstruct). 

Adds a test to validate that `sourceip` (and, in turn, any additional field) doesn't break the core processing loop. 