### PR TITLE
Fix: Update OCS Saver to use GitHub IAM role

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,16 +1,13 @@
 name: Deploy
 description: Deploys new Lambda function code
 inputs:
-  aws-access-key-id:
+  aws-role-to-assume:
     description: AWS access key
-    required: true
-  aws-secret-access-key:
-    description: AWS secret key
     required: true
   dry-run:
     description: >-
       If truthy, the deploy will be a dry run, or will not be attempted at all
-      if `aws-access-key-id` is blank (instead of erroring)
+      if `aws-role-to-assume` is blank (instead of erroring)
     required: false
     default: ""
   environment:
@@ -19,6 +16,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Configure AWS credentials from Test account
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::111111111111:role/my-github-actions-role-test
+        aws-region: us-east-1
+
     - uses: ./.github/actions/deps
 
     - run: ./build.sh src/packager.ts
@@ -32,10 +35,9 @@ runs:
         --zip-file fileb://dist/packager.zip
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
-      if: ${{ !inputs.dry-run || inputs.aws-access-key-id }}
+      if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
       env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-role-to-assume }}
         AWS_REGION: us-east-1
 
     - run: >-
@@ -44,8 +46,7 @@ runs:
         --zip-file fileb://dist/processor.zip
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
-      if: ${{ !inputs.dry-run || inputs.aws-access-key-id }}
+      if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
       env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-role-to-assume }}
         AWS_REGION: us-east-1

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -17,9 +17,9 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials from Test account
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: arn:aws:iam::111111111111:role/my-github-actions-role-test
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
         aws-region: us-east-1
 
     - uses: ./.github/actions/deps
@@ -37,7 +37,7 @@ runs:
       shell: bash
       if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
       env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-role-to-assume }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.aws-role-to-assume }}
         AWS_REGION: us-east-1
 
     - run: >-
@@ -48,5 +48,5 @@ runs:
       shell: bash
       if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
       env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.aws-role-to-assume }}
+        AWS_ROLE_TO_ASSUME: ${{ inputs.aws-role-to-assume }}
         AWS_REGION: us-east-1

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.aws-role-to-assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: us-east-1
 
     - uses: ./.github/actions/deps
@@ -35,7 +35,7 @@ runs:
         --zip-file fileb://dist/packager.zip
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
-      if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
+      if: ${{ !inputs.dry-run || inputs.role-to-assume }}
 
     - run: >-
         aws lambda update-function-code
@@ -43,4 +43,4 @@ runs:
         --zip-file fileb://dist/processor.zip
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
-      if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
+      if: ${{ !inputs.dry-run || inputs.role-to-assume }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Configure AWS credentials from Test account
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-to-assume: ${{ inputs.aws-role-to-assume }}
         aws-region: us-east-1
 
     - uses: ./.github/actions/deps

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,7 +1,7 @@
 name: Deploy
 description: Deploys new Lambda function code
 inputs:
-  aws-role-to-assume:
+  role-to-assume:
     description: AWS access key
     required: true
   dry-run:
@@ -16,10 +16,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Configure AWS credentials from Test account
-      uses: aws-actions/configure-aws-credentials@v1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ inputs.aws-role-to-assume }}
+        role-to-assume: ${{ secrets.aws-role-to-assume }}
         aws-region: us-east-1
 
     - uses: ./.github/actions/deps
@@ -36,9 +36,6 @@ runs:
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
       if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
-      env:
-        AWS_ROLE_TO_ASSUME: ${{ inputs.aws-role-to-assume }}
-        AWS_REGION: us-east-1
 
     - run: >-
         aws lambda update-function-code
@@ -47,6 +44,3 @@ runs:
         ${{ inputs.dry-run && '--dry-run' || '' }}
       shell: bash
       if: ${{ !inputs.dry-run || inputs.aws-role-to-assume }}
-      env:
-        AWS_ROLE_TO_ASSUME: ${{ inputs.aws-role-to-assume }}
-        AWS_REGION: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   deploy:
     name: Dry-deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           dry-run: "true"
           environment: dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           dry-run: "true"
           environment: dev
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,6 +26,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           environment: dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           environment: dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,6 +14,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment: prod
     concurrency: deploy-prod
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,6 +17,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           environment: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/deploy
         with:
-          aws-role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           environment: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     environment: prod
     concurrency: deploy-prod
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Rewrite ocs saver action to use assume role](https://app.asana.com/0/1113545750913664/1205490740478486/f)

Updating the CI, dev, and prod deploy actions to use an assumed IAM role instead of long-lived access keys. 

Successful dev deploy [here](https://app.asana.com/0/1113545750913664/1205490740478486/f)!